### PR TITLE
Type-safe filtering, etc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # build and test
-FROM fpco/stack-build:lts-15.0 AS build
+FROM fpco/stack-build:lts-15.0 AS builder
+LABEL stage=builder
 RUN mkdir -p /opt/build
 COPY . /opt/build
 RUN cd /opt/build && stack build --ghc-options="-Werror" --test --system-ghc
@@ -10,5 +11,5 @@ RUN mkdir -p opt/app
 WORKDIR /opt/app
 RUN apt-get update && apt-get install -y \
   git
-COPY --from=build /opt/build/.stack-work/install/x86_64-linux/7fea63adfe26e95c835361fb032ba3b605ffb9d65e7bf83ead0d3ee19187842b/8.8.2/bin /opt/app
+COPY --from=builder /opt/build/.stack-work/install/x86_64-linux/7fea63adfe26e95c835361fb032ba3b605ffb9d65e7bf83ead0d3ee19187842b/8.8.2/bin /opt/app
 ENTRYPOINT ["/opt/app/git-utils-exe"]

--- a/src/App.hs
+++ b/src/App.hs
@@ -25,8 +25,11 @@ instance MonadGit m => MonadGit (AppT m) where
   grepBranches :: Env -> AppT m [Name]
   grepBranches = lift . grepBranches
 
-  parseStaleBranches :: Env -> [Name] -> AppT m [AppType (UtilsType m AnyBranch)]
-  parseStaleBranches env = lift . (fmap . fmap) AppType . parseStaleBranches env
+  getStaleLogs :: Env -> [Name] -> AppT m (Filtered (AppType (UtilsType m NameAuthDay)))
+  getStaleLogs env = lift . (fmap . fmap) AppType . getStaleLogs env
+
+  toBranches :: Env -> Filtered (AppType (UtilsType m NameAuthDay)) -> AppT m [AppType (UtilsType m AnyBranch)]
+  toBranches env = lift . (fmap . fmap) AppType . toBranches env . fmap unAppType
 
   collectResults :: [AppType (UtilsType m AnyBranch)] -> AppT m (AppResult (UtilsResult m))
   collectResults = lift . fmap AppResult . collectResults . fmap unAppType

--- a/src/Types/Error.hs
+++ b/src/Types/Error.hs
@@ -1,4 +1,7 @@
-module Types.Error (Err(..)) where
+module Types.Error
+( Err(..)
+, ErrOr
+) where
 
 import Data.Text (Text)
 
@@ -10,3 +13,5 @@ data Err
   | GitBranches Text
   | GitLog      Text
   deriving Show
+
+type ErrOr a = Either Err a

--- a/src/Types/GitTypes.hs
+++ b/src/Types/GitTypes.hs
@@ -1,9 +1,16 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module Types.GitTypes
 ( Name(..)
 , Author(..)
 , NameLog
 , NameAuthDateStr
 , NameAuthDay
+, Filtered
+, mkFiltered
+, unFiltered
 ) where
 
 import Data.Text (Text)
@@ -14,3 +21,9 @@ newtype Author = Author Text deriving (Eq, Ord, Show)
 type NameLog = (Name, Text)
 type NameAuthDateStr = (Name, Author, Text)
 type NameAuthDay = (Name, Author, Day)
+
+newtype Filtered a = Filtered { unFiltered :: [a] }
+  deriving (Functor, Applicative, Monad, Foldable, Traversable)
+
+mkFiltered :: (a -> Bool) -> [a] -> Filtered a
+mkFiltered f = Filtered . filter f

--- a/src/Types/ResultsWithErrs.hs
+++ b/src/Types/ResultsWithErrs.hs
@@ -21,11 +21,11 @@ instance Show ResultsWithErrs where
   show ResultsWithErrs{..} = concat str
     where str = ["ERRORS\n------\n", show errList, "\n\n", show results]
 
-toResultsWithErrs :: [Either Err AnyBranch] -> ResultsWithErrs
+toResultsWithErrs :: [ErrOr AnyBranch] -> ResultsWithErrs
 toResultsWithErrs xs = ResultsWithErrs errs (toResults results)
   where (errs, results) = splitErrs xs
 
-splitErrs :: [Either Err AnyBranch] -> ([Err], [AnyBranch])
+splitErrs :: [ErrOr AnyBranch] -> ([Err], [AnyBranch])
 splitErrs = foldl' f ([], [])
   where f (es, bs) (Left e)  = (e:es, bs)
         f (es, bs) (Right b) = (es, b:bs)

--- a/test/spec/Types/ResultsWithErrsSpec.hs
+++ b/test/spec/Types/ResultsWithErrsSpec.hs
@@ -18,14 +18,14 @@ spec = do
   describe "ResultsWithErrs tests" $ do
     prop "size(unique_branches) should equal size(merge_map) + size(unmerged_map) + size(errs)" sizesMatch
 
-sizesMatch :: [Either Err AnyBranch] -> Bool
+sizesMatch :: [ErrOr AnyBranch] -> Bool
 sizesMatch bs = numUnique bs == Map.size merged + Map.size unmerged + length errs
   where resultsErrs  = toResultsWithErrs bs
         merged   = mergedMap   $ results resultsErrs
         unmerged = unmergedMap $ results resultsErrs
         errs     = errList resultsErrs
 
-numUnique :: [Either Err AnyBranch] -> Int
+numUnique :: [ErrOr AnyBranch] -> Int
 numUnique bs = (setsLen . foldl' f (0, Set.empty, Set.empty)) bs
   where f (errs, m, u) (Left _)                                  = (errs + 1, m, u)
         f (errs, m, u) (Right (MergedBranch   (MkBranch _ a _))) = (errs, Set.insert a m, u)


### PR DESCRIPTION
1. Add date filtering back (and Filtered newtype for extra safety)
2. Label intermediate Docker build image for easier deleting
3. Split log and merged logic into separate functions so we don't do unnecessary work (and parallelize both)
4. Update test to include filtering logic