### PR TITLE
Make Reader part of GitUtils IO implementation

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -23,7 +23,7 @@ main = do
   case mkEnv d args of
     Nothing  -> putStrLn "Usage: stack exec git-utils-exe <search str> <path> <limit>"
     Just env -> do
-      runReaderT (runAppT runWithReader) env
+      runReaderT (runAppT runGitUtils) env
       stopGlobalPool
 
 mkEnv :: Day -> [String] -> Maybe Env

--- a/src/App.hs
+++ b/src/App.hs
@@ -1,45 +1,13 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE InstanceSigs               #-}
-{-# LANGUAGE TypeFamilies               #-}
 
 module App
   ( AppT(..)
   )
 where
 
-import           Control.Monad.Reader
+import qualified Control.Monad.Reader as R
 
-import           Core.MonadGit
-import           Types.Branch
 import           Types.Env
-import           Types.GitTypes
 
-newtype AppT m a = AppT { runAppT :: ReaderT Env m a }
-  deriving (Functor, Applicative, Monad, MonadIO, MonadTrans, MonadReader Env)
-
-newtype AppType a = AppType { unAppType :: a }
-newtype AppResult a = AppResult { unAppResult :: a }
-instance MonadGit m => MonadGit (AppT m) where
-  type GitType (AppT m) a = AppType (GitType m a)
-  type ResultType (AppT m) = AppResult (ResultType m)
-
-  grepBranches :: Env -> AppT m [Name]
-  grepBranches = lift . grepBranches
-
-  getStaleLogs
-    :: Env -> [Name] -> AppT m (Filtered (AppType (GitType m NameAuthDay)))
-  getStaleLogs env = lift . (fmap . fmap) AppType . getStaleLogs env
-
-  toBranches
-    :: Env
-    -> Filtered (AppType (GitType m NameAuthDay))
-    -> AppT m [AppType (GitType m AnyBranch)]
-  toBranches env =
-    lift . (fmap . fmap) AppType . toBranches env . fmap unAppType
-
-  collectResults
-    :: [AppType (GitType m AnyBranch)] -> AppT m (AppResult (ResultType m))
-  collectResults = lift . fmap AppResult . collectResults . fmap unAppType
-
-  display :: AppResult (ResultType m) -> AppT m ()
-  display = lift . display . unAppResult
+newtype AppT m a = AppT { runAppT :: R.ReaderT Env m a }
+  deriving (Functor, Applicative, Monad, R.MonadIO, R.MonadTrans, R.MonadReader Env)

--- a/src/Core/Internal.hs
+++ b/src/Core/Internal.hs
@@ -14,10 +14,10 @@ module Core.Internal
   )
 where
 
-import           Control.Monad ((>=>))
-import qualified Data.Text as T
-import qualified Data.Time.Calendar as C
-import qualified Text.Read as R
+import           Control.Monad                  ( (>=>) )
+import qualified Data.Text                     as T
+import qualified Data.Time.Calendar            as C
+import qualified Text.Read                     as R
 
 import           Types.Error
 import           Types.GitTypes

--- a/test/spec/Core/MockSpec.hs
+++ b/test/spec/Core/MockSpec.hs
@@ -6,7 +6,6 @@ import           Control.Monad.Reader           ( runReaderT )
 import qualified Data.Text                     as Txt
 import           Test.Hspec
 
-import           App
 import           Core.MonadGit
 import           Types.Env
 
@@ -16,24 +15,24 @@ spec :: Spec
 spec = do
   describe "MockUtils tests" $ do
     it "Mock run with grep `branch` should return 5 results" $ do
-      let (MockUtils res _) = runMock "branch"
+      let (Output res _) = runMock "branch"
       length res `shouldBe` 5
 
     it "Mock run with grep `other` should return 3 results" $ do
-      let (MockUtils res _) = runMock "other"
+      let (Output res _) = runMock "other"
       length res `shouldBe` 3
 
     it "Mock run with blank grep should return 8 results" $ do
-      let (MockUtils res _) = runMock ""
+      let (Output res _) = runMock ""
       length res `shouldBe` 8
 
     it "Mock run with wrong grep should return 0 results" $ do
-      let (MockUtils res _) = runMock "nope"
+      let (Output res _) = runMock "nope"
       length res `shouldBe` 0
 
-runMock :: Txt.Text -> MockUtils ()
+runMock :: Txt.Text -> Output ()
 runMock t = do
-  runReaderT (runAppT runWithReader) (envWithGrep t)
+  runReaderT (runMockUtilsT runGitUtils) (envWithGrep t)
 
 envWithGrep :: Txt.Text -> Env
 envWithGrep "" = Env Nothing undefined undefined undefined


### PR DESCRIPTION
Moved `ReaderT` into `GitUtils` impl because it's easier than passing `Env` around directly (downside is anyone else wanting to use `ReaderT Env m` will have to define their own instances.

Also removed type family injectivity for now.