### PR TITLE
FF and name updates

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,9 +8,9 @@ import Control.Concurrent.ParallelIO.Global
 import Control.Monad.Reader (runReaderT)
 import Data.Time.Calendar (Day)
 import Data.Time.Clock (getCurrentTime, utctDay)
-import Git.FastForward.Core.UpdateBranches
+import Git.FastForward.Core.MonadUpdateBranches
 import qualified Git.FastForward.Parsing as FF
-import Git.Stale.Core.FindBranches
+import Git.Stale.Core.MonadFindBranches
 import qualified Git.Stale.Parsing as Stale
 import Git.Stale.Types.Env ()
 import System.Environment (getArgs)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                git-utils
-version:             2.1.0
+version:             3.0.0
 github:              "tbidne/git-utils"
 license:             BSD3
 author:              "Thomas Bidne"

--- a/src/Git/FastForward/Core/IO.hs
+++ b/src/Git/FastForward/Core/IO.hs
@@ -4,7 +4,7 @@
 -- Module      : Git.FastForward.Core.IO
 -- License     : BSD3
 -- Maintainer  : tbidne@gmail.com
--- Exports functions to be used by "Git.FastForward.Core.UpdateBranches" for `IO`.
+-- Exports functions to be used by "Git.FastForward.Core.MonadUpdateBranches" for `IO`.
 module Git.FastForward.Core.IO
   ( checkoutCurrentIO,
     fetchIO,

--- a/src/Git/FastForward/Core/MonadUpdateBranches.hs
+++ b/src/Git/FastForward/Core/MonadUpdateBranches.hs
@@ -3,12 +3,12 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 -- |
--- Module      : Git.FastForward.Core.UpdateBranches
+-- Module      : Git.FastForward.Core.MonadUpdateBranches
 -- License     : BSD3
 -- Maintainer  : tbidne@gmail.com
--- The UpdateBranches class.
-module Git.FastForward.Core.UpdateBranches
-  ( UpdateBranches (..),
+-- The MonadUpdateBranches class.
+module Git.FastForward.Core.MonadUpdateBranches
+  ( MonadUpdateBranches (..),
     runUpdateBranches,
   )
 where
@@ -21,9 +21,9 @@ import Git.FastForward.Types.LocalBranches
 import Git.FastForward.Types.UpdateResult
 import Git.Types.GitTypes
 
--- | The 'UpdateBranches' class is used to describe updating branches
+-- | The 'MonadUpdateBranches' class is used to describe updating branches
 -- on a git filesystem.
-class Monad m => UpdateBranches m where
+class Monad m => MonadUpdateBranches m where
   -- | Performs 'fetch'.
   fetch :: m ()
 
@@ -42,12 +42,12 @@ class Monad m => UpdateBranches m where
   -- | Checks out the passed 'CurrentBranch'.
   checkoutCurrent :: CurrentBranch -> m ()
 
--- | `UpdateBranches` instance for (`AppT` m) over `R.MonadIO`. In general, we
+-- | `MonadUpdateBranches` instance for (`AppT` m) over `R.MonadIO`. In general, we
 -- do not care about error handling /except/ during 'updateBranch'. This is
 -- because a failure during 'updateBranch' is relatively common as we're
 -- being conservative by merging with "--ff-only", and we'd rather log it
 -- and continue trying to update other branches.
-instance R.MonadIO m => UpdateBranches (AppT Env m) where
+instance R.MonadIO m => MonadUpdateBranches (AppT Env m) where
   fetch :: AppT Env m ()
   fetch = do
     Env {path} <- R.ask
@@ -76,9 +76,9 @@ instance R.MonadIO m => UpdateBranches (AppT Env m) where
     Env {path} <- R.ask
     R.liftIO $ checkoutCurrentIO curr path
 
--- | High level logic of `UpdateBranches` usage. This function is the
--- entrypoint for any `UpdateBranches` instance.
-runUpdateBranches :: UpdateBranches m => m ()
+-- | High level logic of `MonadUpdateBranches` usage. This function is the
+-- entrypoint for any `MonadUpdateBranches` instance.
+runUpdateBranches :: MonadUpdateBranches m => m ()
 runUpdateBranches = do
   fetch
   LocalBranches {current, branches} <- getBranches

--- a/src/Git/FastForward/Parsing.hs
+++ b/src/Git/FastForward/Parsing.hs
@@ -26,7 +26,7 @@ import Git.Types.GitTypes
 --       Path to the git directory. Any `String` is fine, defaults
 --       to the empty string (current directory).
 --
---   -u, --merge-type=upstream
+--   -u, --merge=upstream
 --       Merges upstream via @{u} into each local branch. This is the default.
 --
 --   -m, --branch-type=master
@@ -75,7 +75,7 @@ pathParser = AnyParser $ PrefixParser ("--path=", parser, updater)
     updater env p = env {path = p}
 
 mergeTypeParser :: AnyParser Env
-mergeTypeParser = AnyParser $ PrefixParser ("--merge-type=", parser, updater)
+mergeTypeParser = AnyParser $ PrefixParser ("--merge=", parser, updater)
   where
     parser "" = Nothing
     parser "upstream" = Just Upstream
@@ -109,9 +109,9 @@ help =
   "\nUsage: git-utils fastforward [OPTIONS]\n\n"
     <> "Fast-forwards all local branches with --ff-only.\n\nOptions:\n"
     <> "  --path=<string>\t\tDirectory path, defaults to current directory.\n\n"
-    <> "  -u, --merge-type=upstream\tMerges each branches' upstream via @{u}. This is the default.\n\n"
-    <> "  -m, --merge-type=master\tMerges origin/master into each branch.\n\n"
-    <> "  --merge-type=<string>\t\tMerges branch given by <string> into each branch.\n\n"
+    <> "  -u, --merge=upstream\tMerges each branches' upstream via @{u}. This is the default.\n\n"
+    <> "  -m, --merge=master\tMerges origin/master into each branch.\n\n"
+    <> "  --merge=<string>\t\tMerges branch given by <string> into each branch.\n\n"
     <> "  --push=<list>\t\t\tList of branches to push to after we're done updating.\n"
     <> "\t\t\t\tEach branch is formatted \"remote_name branch_name\",\n"
     <> "\t\t\t\tand each \"remote_name branch_name\" is separated by a comma.\n"

--- a/src/Git/Stale/Core/IO.hs
+++ b/src/Git/Stale/Core/IO.hs
@@ -2,10 +2,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
--- Module      : Git.Stale.Core.FindBranches
+-- Module      : Git.Stale.Core.IO
 -- License     : BSD3
 -- Maintainer  : tbidne@gmail.com
--- Exports functions to be used by "Git.Stale.Core.FindBranches" for `IO`.
+-- Exports functions to be used by "Git.Stale.Core.MonadFindBranches" for `IO`.
 module Git.Stale.Core.IO
   ( errTupleToBranch,
     logIfErr,

--- a/src/Git/Stale/Core/Internal.hs
+++ b/src/Git/Stale/Core/Internal.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TupleSections #-}
 
 -- |
--- Module      : Git.Stale.Core.FindBranches
+-- Module      : Git.Stale.Core.Internal
 -- License     : BSD3
 -- Maintainer  : tbidne@gmail.com
 -- Exports utility functions mainly for parsing/transforming

--- a/src/Git/Stale/Core/MonadFindBranches.hs
+++ b/src/Git/Stale/Core/MonadFindBranches.hs
@@ -7,12 +7,12 @@
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
--- Module      : Git.Stale.Core.FindBranches
+-- Module      : Git.Stale.Core.MonadFindBranches
 -- License     : BSD3
 -- Maintainer  : tbidne@gmail.com
--- The FindBranches class.
-module Git.Stale.Core.FindBranches
-  ( FindBranches (..),
+-- The MonadFindBranches class.
+module Git.Stale.Core.MonadFindBranches
+  ( MonadFindBranches (..),
     runFindBranches,
   )
 where
@@ -31,9 +31,9 @@ import Git.Stale.Types.Filtered
 import Git.Stale.Types.ResultsWithErrs
 import Git.Types.GitTypes
 
--- | The 'FindBranches' class is used to describe various git
+-- | The 'MonadFindBranches' class is used to describe various git
 -- actions for finding stale branches.
-class Monad m => FindBranches m where
+class Monad m => MonadFindBranches m where
   -- | Adds custom handling to returned data (e.g. for error handling).
   type Handler (m :: K.Type -> K.Type) (a :: K.Type)
 
@@ -55,7 +55,7 @@ class Monad m => FindBranches m where
   -- | Displays results.
   display :: FinalResults m -> m ()
 
--- | `FindBranches` instance for (`AppT` m) over `R.MonadIO`. This means we can
+-- | `MonadFindBranches` instance for (`AppT` m) over `R.MonadIO`. This means we can
 -- encounter exceptions, but
 --
 --   * We do not want a single exception trying to parse one branch kill
@@ -66,7 +66,7 @@ class Monad m => FindBranches m where
 -- and two maps, one for merged branches and another for unmerged branches. 
 -- We opt to define `Handler` as (`ErrOr` a) -- an alias for
 -- (`Either` `Err` a) -- as we do not want a single error to crash the app.
-instance R.MonadIO m => FindBranches (AppT Env m) where
+instance R.MonadIO m => MonadFindBranches (AppT Env m) where
   type Handler (AppT Env m) a = ErrOr a
 
   type FinalResults (AppT Env m) = ResultsWithErrs
@@ -104,9 +104,9 @@ instance R.MonadIO m => FindBranches (AppT Env m) where
     Env {remoteName} <- R.ask
     R.liftIO $ putStrLn $ T.unpack $ displayResultsWithErrs remoteName res
 
--- | High level logic of `FindBranches` usage. This function is the
--- entrypoint for any `FindBranches` instance.
-runFindBranches :: FindBranches m => m ()
+-- | High level logic of `MonadFindBranches` usage. This function is the
+-- entrypoint for any `MonadFindBranches` instance.
+runFindBranches :: MonadFindBranches m => m ()
 runFindBranches = do
   branchNames <- branchNamesByGrep
   staleLogs <- getStaleLogs branchNames

--- a/src/Git/Stale/Types/Branch.hs
+++ b/src/Git/Stale/Types/Branch.hs
@@ -35,7 +35,7 @@ data Branch (a :: BranchStatus) where
 -- | Maps each [`Branch` 'a'] to its `T.Text` `Name` and concatenates results.
 -- Attempts to strip out an irrelevant prefix it may have (i.e. `Types.Env.remoteName`).
 branchesToName :: T.Text -> [Branch a] -> T.Text
-branchesToName prefix branches = "[" <> T.intercalate "," names <> "]"
+branchesToName prefix branches = "[" <> T.intercalate " " names <> "]"
   where
     names = branchToName prefix <$> branches
 

--- a/src/Git/Stale/Types/Env.hs
+++ b/src/Git/Stale/Types/Env.hs
@@ -22,8 +22,8 @@ data BranchType
   | Local
   deriving (Eq, Show)
 
--- | Maps a `BranchType` to a `String` flag to be used in "Core.FindBranches"'
--- `Core.FindBranches.branchNamesByGrep` command.
+-- | Maps a `BranchType` to a `String` flag to be used in "Core.MonadFindBranches"'
+-- `Core.MonadFindBranches.branchNamesByGrep` command.
 branchTypeToArg :: BranchType -> String
 branchTypeToArg All = "-a"
 branchTypeToArg Remote = "-r"

--- a/src/Git/Stale/Types/Error.hs
+++ b/src/Git/Stale/Types/Error.hs
@@ -12,7 +12,7 @@ where
 import qualified Data.Text as T
 
 -- | Wraps `T.Text` to describe an error. 'Git'* errors describe errors
--- encountered by the underlying `Core.FindBranches.FindBranches`
+-- encountered by the underlying `Core.MonadFindBranches.MonadFindBranches`
 -- monad. Others describe pure errors encountered during parsing data returned
 -- by the monad.
 data Err

--- a/src/Git/Stale/Types/Filtered.hs
+++ b/src/Git/Stale/Types/Filtered.hs
@@ -9,7 +9,7 @@ module Git.Stale.Types.Filtered
   )
 where
 
--- | Intermediate type to ensure `Core.FindBranches.getStaleLogs`
+-- | Intermediate type to ensure `Core.MonadFindBranches.getStaleLogs`
 -- filters stale logs.
 newtype Filtered a = Filtered {unFiltered :: [a]}
 

--- a/test/functional/Git/Stale/FunctionalSpec.hs
+++ b/test/functional/Git/Stale/FunctionalSpec.hs
@@ -8,7 +8,7 @@ import Common.Utils
 import qualified Control.Monad.Reader as R
 import qualified Data.Time.Calendar as Cal
 import qualified Data.Time.Clock as Clock
-import Git.Stale.Core.FindBranches
+import Git.Stale.Core.MonadFindBranches
 import Git.Stale.Parsing
 import Git.Stale.Types.Env
 import qualified System.IO as IO

--- a/test/inttest/Git/FastForward/Core/MockUpdateBranches.hs
+++ b/test/inttest/Git/FastForward/Core/MockUpdateBranches.hs
@@ -8,23 +8,24 @@
 module Git.FastForward.Core.MockUpdateBranches where
 
 import Control.Monad.Reader
-import Git.FastForward.Core.UpdateBranches
+import Git.FastForward.Core.MonadUpdateBranches
 import Git.FastForward.Types.Env
 import Git.FastForward.Types.LocalBranches
 import Git.FastForward.Types.UpdateResult
 import Git.Types.GitTypes
 import Output
 
-newtype MockUpdateBranchesT m a = MockUpdateBranchesT {runMockUpdateBranchesT :: ReaderT Env m a}
+newtype MockUpdateT m a = MockUpdateT {runMockUpdateT :: ReaderT Env m a}
   deriving (Functor, Applicative, Monad, MonadTrans, MonadReader Env)
 
-type MockUpdateBranchesOut = MockUpdateBranchesT Output
+type MockUpdateOut = MockUpdateT Output
 
-instance UpdateBranches MockUpdateBranchesOut where
-  fetch :: MockUpdateBranchesOut ()
-  fetch = lift $ putSingleOutput ("Fetching" :: String)
 
-  getBranches :: MockUpdateBranchesOut LocalBranches
+instance MonadUpdateBranches MockUpdateOut where
+  fetch :: MockUpdateOut ()
+  fetch = lift $ putShowable ("Fetching" :: String)
+
+  getBranches :: MockUpdateOut LocalBranches
   getBranches =
     lift $ pure $
       LocalBranches
@@ -37,25 +38,25 @@ instance UpdateBranches MockUpdateBranchesOut where
           Name "failure2"
         ]
 
-  updateBranch :: Name -> MockUpdateBranchesOut UpdateResult
+  updateBranch :: Name -> MockUpdateOut UpdateResult
   updateBranch nm@(Name "success1") = lift $ pure $ Success nm
   updateBranch nm@(Name "success2") = lift $ pure $ Success nm
   updateBranch nm@(Name "noChange1") = lift $ pure $ NoChange nm
   updateBranch nm@(Name "noChange2") = lift $ pure $ NoChange nm
   updateBranch nm@(Name "failure1") = lift $ pure $ Failure nm
   updateBranch nm@(Name "failure2") = lift $ pure $ Failure nm
-  updateBranch _ = error "Mock UpdateBranches is missing a pattern!"
+  updateBranch _ = error "Mock MonadUpdateBranches is missing a pattern!"
 
-  summarize :: [UpdateResult] -> MockUpdateBranchesOut ()
-  summarize = lift . putOutput
+  summarize :: [UpdateResult] -> MockUpdateOut ()
+  summarize = lift . putShowList
 
-  pushBranches :: MockUpdateBranchesOut [UpdateResult]
+  pushBranches :: MockUpdateOut [UpdateResult]
   pushBranches = do
     Env {push} <- ask
     lift $ pure $ fmap nameToResult push
 
-  checkoutCurrent :: CurrentBranch -> MockUpdateBranchesOut ()
-  checkoutCurrent (Name nm) = lift $ putSingleOutput ("Checked out " <> nm)
+  checkoutCurrent :: CurrentBranch -> MockUpdateOut ()
+  checkoutCurrent (Name nm) = lift $ putShowable ("Checked out " <> nm)
 
 nameToResult :: Name -> UpdateResult
 nameToResult = Success

--- a/test/inttest/Git/FastForward/MockSpec.hs
+++ b/test/inttest/Git/FastForward/MockSpec.hs
@@ -5,7 +5,7 @@ module Git.FastForward.MockSpec where
 import Control.Monad.Reader (runReaderT)
 import qualified Data.Text as T
 import Git.FastForward.Core.MockUpdateBranches
-import Git.FastForward.Core.UpdateBranches
+import Git.FastForward.Core.MonadUpdateBranches
 import Git.FastForward.Parsing
 import Git.FastForward.Types.Env
 import Output
@@ -19,12 +19,12 @@ spec = do
       res `shouldSatisfy` verifyOutput
 
 runMock :: Output ()
-runMock = runReaderT (runMockUpdateBranchesT runUpdateBranches) mkEnv
+runMock = runReaderT (runMockUpdateT runUpdateBranches) mkEnv
 
 args :: [String]
 args =
   [ "--path=",
-    "--merge-type=master",
+    "--merge=master",
     "--push=origin push1, remote push2"
   ]
 

--- a/test/inttest/Git/Stale/Core/MockFindBranches.hs
+++ b/test/inttest/Git/Stale/Core/MockFindBranches.hs
@@ -9,7 +9,7 @@ module Git.Stale.Core.MockFindBranches where
 
 import Control.Monad.Reader
 import qualified Data.Text as Txt
-import Git.Stale.Core.FindBranches
+import Git.Stale.Core.MonadFindBranches
 import Git.Stale.Types.Branch
 import Git.Stale.Types.Env
 import Git.Stale.Types.Filtered
@@ -21,7 +21,7 @@ newtype MockFindBranchesT m a = MockFindBranchesT {runMockFindBranchesT :: Reade
 
 type MockFindBranchesOut = MockFindBranchesT Output
 
-instance FindBranches MockFindBranchesOut where
+instance MonadFindBranches MockFindBranchesOut where
   type Handler MockFindBranchesOut a = a
   type FinalResults MockFindBranchesOut = [AnyBranch]
 
@@ -48,10 +48,10 @@ instance FindBranches MockFindBranchesOut where
   collectResults = lift . return
 
   display :: [AnyBranch] -> MockFindBranchesOut ()
-  display = MockFindBranchesT . lift . putOutput
+  display = MockFindBranchesT . lift . putShowList
 
 addMockOut :: [Txt.Text] -> MockFindBranchesOut a -> MockFindBranchesOut a
-addMockOut ts = MockFindBranchesT . mapReaderT (prependOut ts) . runMockFindBranchesT
+addMockOut ts = MockFindBranchesT . mapReaderT (prependTextList ts) . runMockFindBranchesT
 
 allBranches :: [Name]
 allBranches =

--- a/test/inttest/Git/Stale/MockSpec.hs
+++ b/test/inttest/Git/Stale/MockSpec.hs
@@ -2,7 +2,7 @@ module Git.Stale.MockSpec where
 
 import Control.Monad.Reader (runReaderT)
 import qualified Data.Time.Calendar as Cal
-import Git.Stale.Core.FindBranches
+import Git.Stale.Core.MonadFindBranches
 import Git.Stale.Core.MockFindBranches
 import Git.Stale.Types.Env
 import Git.Stale.Parsing

--- a/test/inttest/Output.hs
+++ b/test/inttest/Output.hs
@@ -25,11 +25,17 @@ instance Monad Output where
   (>>=) :: Output a -> (a -> Output b) -> Output b
   (Output rs x) >>= f = Output (rs <> ts) y where (Output ts y) = f x
 
-putOutput :: Show a => [a] -> Output ()
-putOutput xs = Output (fmap (T.pack . show) xs) ()
+putShowList :: Show a => [a] -> Output ()
+putShowList xs = Output (fmap (T.pack . show) xs) ()
 
-putSingleOutput :: Show a => a -> Output ()
-putSingleOutput x = Output [(T.pack . show) x] ()
+putShowable :: Show a => a -> Output ()
+putShowable x = Output [(T.pack . show) x] ()
 
-prependOut :: [T.Text] -> Output a -> Output a
-prependOut ts (Output rs x) = Output (ts <> rs) x
+putText :: T.Text -> Output ()
+putText t = Output [t] ()
+
+prependTextList :: [T.Text] -> Output a -> Output a
+prependTextList ts (Output rs x) = Output (ts <> rs) x
+
+prependText :: T.Text -> Output a -> Output a
+prependText r (Output rs x) = Output (r : rs) x

--- a/test/spec/Git/FastForward/Arbitraries.hs
+++ b/test/spec/Git/FastForward/Arbitraries.hs
@@ -16,11 +16,11 @@ instance Arbitrary ValidMergeType where
     (PrintableString p) <- arbitrary `suchThat` \(PrintableString s) -> s /= ""
     bt <-
       elements
-        [ "--merge-type=upstream",
+        [ "--merge=upstream",
           "-u",
-          "--merge-type=master",
+          "--merge=master",
           "-m",
-          "--merge-type=" <> p
+          "--merge=" <> p
         ]
     pure $ ValidMergeType bt
 

--- a/test/spec/Git/FastForward/ParsingSpec.hs
+++ b/test/spec/Git/FastForward/ParsingSpec.hs
@@ -45,11 +45,11 @@ verifyPath (matchAndStrip "--path=" -> Just s) (Just s') = s == s'
 verifyPath _ _ = False
 
 verifyMergeType :: String -> MergeType -> Bool
-verifyMergeType "--merge-type=upstream" Upstream = True
+verifyMergeType "--merge=upstream" Upstream = True
 verifyMergeType "-u" Upstream = True
-verifyMergeType "--merge-type=master" Master = True
+verifyMergeType "--merge=master" Master = True
 verifyMergeType "-m" Master = True
-verifyMergeType (matchAndStrip "--merge-type=" -> Just s) (Other (Name n)) = (T.pack s) == n
+verifyMergeType (matchAndStrip "--merge=" -> Just s) (Other (Name n)) = (T.pack s) == n
 verifyMergeType _ _ = False
 
 invalidArgsDies :: InvalidArgs -> Bool


### PR DESCRIPTION
1. Rename typeclasses to include Monad*.
2. Rename FF '--merge-type' arg to '--merge'.
3. Change find-stale output to be separated by spaces, not commas.